### PR TITLE
remove .codex file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ bun.lock
 *.diff.png
 
 .vscode
+.codex


### PR DESCRIPTION
The .codex file was added incidentally in the last PR and wasn’t intended to be part of the change. I’ve removed it from this PR.