### PR TITLE
Add transparent drill cutouts

### DIFF
--- a/lib/drawer/CircuitToCanvasDrawer.ts
+++ b/lib/drawer/CircuitToCanvasDrawer.ts
@@ -104,6 +104,8 @@ export interface DrawElementsOptions {
   minBoardOutlineStrokePx?: number
   /** Whether to render pcb_note elements. Defaults to true. */
   showPcbNotes?: boolean
+  /** Clear drill holes and cutouts from the canvas instead of painting them with the drill color. Defaults to false. */
+  clearDrillHoles?: boolean
 }
 
 interface CanvasLike {
@@ -120,6 +122,22 @@ function getCopperLayer(layers?: PcbRenderLayer[]): LayerRef {
 
 const isOnCopperLayer = (element: PcbVia | PcbPlatedHole, layer: LayerRef) =>
   element.layers?.includes(layer) ?? true
+
+const drawAsCutout = (
+  ctx: CanvasContext,
+  enabled: boolean,
+  draw: () => void,
+) => {
+  if (!enabled) {
+    draw()
+    return
+  }
+
+  ctx.save()
+  ctx.globalCompositeOperation = "destination-out"
+  draw()
+  ctx.restore()
+}
 
 export class CircuitToCanvasDrawer {
   private ctx: CanvasContext
@@ -207,6 +225,13 @@ export class CircuitToCanvasDrawer {
     options: DrawElementsOptions = {},
   ): void {
     const layer = getCopperLayer(options.layers)
+    const clearDrillHoles = options.clearDrillHoles ?? false
+    const transparentDrillColorMap = clearDrillHoles
+      ? { ...this.colorMap, drill: "rgba(0,0,0,0)" }
+      : this.colorMap
+    const opaqueDrillColorMap = clearDrillHoles
+      ? { ...this.colorMap, drill: "#000" }
+      : this.colorMap
 
     // Find the board or panel element
     const board = elements.find((el) => el.type === "pcb_board") as
@@ -373,15 +398,17 @@ export class CircuitToCanvasDrawer {
         if (!shouldDrawElement(element, options)) continue
 
         if (element.type === "pcb_hole") {
-          drawPcbHole({
-            ctx: this.ctx,
-            hole: element as PcbHole,
-            realToCanvasMat: this.realToCanvasMat,
-            colorMap: this.colorMap,
-            soldermaskMargin: renderTopSoldermask
-              ? element.soldermask_margin
-              : undefined,
-            drawSoldermask: renderTopSoldermask,
+          drawAsCutout(this.ctx, clearDrillHoles, () => {
+            drawPcbHole({
+              ctx: this.ctx,
+              hole: element as PcbHole,
+              realToCanvasMat: this.realToCanvasMat,
+              colorMap: opaqueDrillColorMap,
+              soldermaskMargin: renderTopSoldermask
+                ? element.soldermask_margin
+                : undefined,
+              drawSoldermask: renderTopSoldermask,
+            })
           })
         }
 
@@ -393,7 +420,7 @@ export class CircuitToCanvasDrawer {
             ctx: this.ctx,
             hole: element as PcbPlatedHole,
             realToCanvasMat: this.realToCanvasMat,
-            colorMap: this.colorMap,
+            colorMap: transparentDrillColorMap,
             soldermaskMargin: renderTopSoldermask
               ? (element as PcbPlatedHole).soldermask_margin
               : undefined,
@@ -407,7 +434,7 @@ export class CircuitToCanvasDrawer {
             ctx: this.ctx,
             via: element as PcbVia,
             realToCanvasMat: this.realToCanvasMat,
-            colorMap: this.colorMap,
+            colorMap: transparentDrillColorMap,
             layer,
           })
         }
@@ -537,15 +564,17 @@ export class CircuitToCanvasDrawer {
       if (!shouldDrawElement(element, options)) continue
 
       if (element.type === "pcb_hole" && !renderTopLayerOverlay) {
-        drawPcbHole({
-          ctx: this.ctx,
-          hole: element as PcbHole,
-          realToCanvasMat: this.realToCanvasMat,
-          colorMap: this.colorMap,
-          soldermaskMargin: renderTopSoldermask
-            ? element.soldermask_margin
-            : undefined,
-          drawSoldermask: renderTopSoldermask,
+        drawAsCutout(this.ctx, clearDrillHoles, () => {
+          drawPcbHole({
+            ctx: this.ctx,
+            hole: element as PcbHole,
+            realToCanvasMat: this.realToCanvasMat,
+            colorMap: opaqueDrillColorMap,
+            soldermaskMargin: renderTopSoldermask
+              ? element.soldermask_margin
+              : undefined,
+            drawSoldermask: renderTopSoldermask,
+          })
         })
       }
     }
@@ -563,7 +592,7 @@ export class CircuitToCanvasDrawer {
           ctx: this.ctx,
           hole: element as PcbPlatedHole,
           realToCanvasMat: this.realToCanvasMat,
-          colorMap: this.colorMap,
+          colorMap: transparentDrillColorMap,
           soldermaskMargin: renderTopSoldermask
             ? (element as PcbPlatedHole).soldermask_margin
             : undefined,
@@ -581,7 +610,7 @@ export class CircuitToCanvasDrawer {
           ctx: this.ctx,
           via: element as PcbVia,
           realToCanvasMat: this.realToCanvasMat,
-          colorMap: this.colorMap,
+          colorMap: transparentDrillColorMap,
           layer,
         })
       }
@@ -619,11 +648,13 @@ export class CircuitToCanvasDrawer {
       if (!shouldDrawElement(element, options)) continue
 
       if (element.type === "pcb_cutout") {
-        drawPcbCutout({
-          ctx: this.ctx,
-          cutout: element as PcbCutout,
-          realToCanvasMat: this.realToCanvasMat,
-          colorMap: this.colorMap,
+        drawAsCutout(this.ctx, clearDrillHoles, () => {
+          drawPcbCutout({
+            ctx: this.ctx,
+            cutout: element as PcbCutout,
+            realToCanvasMat: this.realToCanvasMat,
+            colorMap: opaqueDrillColorMap,
+          })
         })
       }
     }

--- a/lib/drawer/CircuitToCanvasDrawer.ts
+++ b/lib/drawer/CircuitToCanvasDrawer.ts
@@ -114,30 +114,15 @@ interface CanvasLike {
 
 function getCopperLayer(layers?: PcbRenderLayer[]): LayerRef {
   if (!layers || layers.length === 0) return "top"
-  const copperLayer = layers.find((candidate) => candidate.endsWith("_copper"))
-  return copperLayer
-    ? (copperLayer.slice(0, -"_copper".length) as LayerRef)
-    : "top"
+  const renderLayer =
+    layers.find((candidate) => candidate.endsWith("_copper")) ??
+    layers[0] ??
+    "top_copper"
+  return renderLayer.split("_")[0] as LayerRef
 }
 
 const isOnCopperLayer = (element: PcbVia | PcbPlatedHole, layer: LayerRef) =>
   element.layers?.includes(layer) ?? true
-
-const drawAsCutout = (
-  ctx: CanvasContext,
-  enabled: boolean,
-  draw: () => void,
-) => {
-  if (!enabled) {
-    draw()
-    return
-  }
-
-  ctx.save()
-  ctx.globalCompositeOperation = "destination-out"
-  draw()
-  ctx.restore()
-}
 
 export class CircuitToCanvasDrawer {
   private ctx: CanvasContext
@@ -225,13 +210,6 @@ export class CircuitToCanvasDrawer {
     options: DrawElementsOptions = {},
   ): void {
     const layer = getCopperLayer(options.layers)
-    const clearDrillHoles = options.clearDrillHoles ?? false
-    const transparentDrillColorMap = clearDrillHoles
-      ? { ...this.colorMap, drill: "rgba(0,0,0,0)" }
-      : this.colorMap
-    const opaqueDrillColorMap = clearDrillHoles
-      ? { ...this.colorMap, drill: "#000" }
-      : this.colorMap
 
     // Find the board or panel element
     const board = elements.find((el) => el.type === "pcb_board") as
@@ -398,17 +376,15 @@ export class CircuitToCanvasDrawer {
         if (!shouldDrawElement(element, options)) continue
 
         if (element.type === "pcb_hole") {
-          drawAsCutout(this.ctx, clearDrillHoles, () => {
-            drawPcbHole({
-              ctx: this.ctx,
-              hole: element as PcbHole,
-              realToCanvasMat: this.realToCanvasMat,
-              colorMap: opaqueDrillColorMap,
-              soldermaskMargin: renderTopSoldermask
-                ? element.soldermask_margin
-                : undefined,
-              drawSoldermask: renderTopSoldermask,
-            })
+          drawPcbHole({
+            ctx: this.ctx,
+            hole: element as PcbHole,
+            realToCanvasMat: this.realToCanvasMat,
+            colorMap: this.colorMap,
+            soldermaskMargin: renderTopSoldermask
+              ? element.soldermask_margin
+              : undefined,
+            drawSoldermask: renderTopSoldermask,
           })
         }
 
@@ -420,7 +396,7 @@ export class CircuitToCanvasDrawer {
             ctx: this.ctx,
             hole: element as PcbPlatedHole,
             realToCanvasMat: this.realToCanvasMat,
-            colorMap: transparentDrillColorMap,
+            colorMap: this.colorMap,
             soldermaskMargin: renderTopSoldermask
               ? (element as PcbPlatedHole).soldermask_margin
               : undefined,
@@ -434,7 +410,7 @@ export class CircuitToCanvasDrawer {
             ctx: this.ctx,
             via: element as PcbVia,
             realToCanvasMat: this.realToCanvasMat,
-            colorMap: transparentDrillColorMap,
+            colorMap: this.colorMap,
             layer,
           })
         }
@@ -564,17 +540,15 @@ export class CircuitToCanvasDrawer {
       if (!shouldDrawElement(element, options)) continue
 
       if (element.type === "pcb_hole" && !renderTopLayerOverlay) {
-        drawAsCutout(this.ctx, clearDrillHoles, () => {
-          drawPcbHole({
-            ctx: this.ctx,
-            hole: element as PcbHole,
-            realToCanvasMat: this.realToCanvasMat,
-            colorMap: opaqueDrillColorMap,
-            soldermaskMargin: renderTopSoldermask
-              ? element.soldermask_margin
-              : undefined,
-            drawSoldermask: renderTopSoldermask,
-          })
+        drawPcbHole({
+          ctx: this.ctx,
+          hole: element as PcbHole,
+          realToCanvasMat: this.realToCanvasMat,
+          colorMap: this.colorMap,
+          soldermaskMargin: renderTopSoldermask
+            ? element.soldermask_margin
+            : undefined,
+          drawSoldermask: renderTopSoldermask,
         })
       }
     }
@@ -592,7 +566,7 @@ export class CircuitToCanvasDrawer {
           ctx: this.ctx,
           hole: element as PcbPlatedHole,
           realToCanvasMat: this.realToCanvasMat,
-          colorMap: transparentDrillColorMap,
+          colorMap: this.colorMap,
           soldermaskMargin: renderTopSoldermask
             ? (element as PcbPlatedHole).soldermask_margin
             : undefined,
@@ -610,7 +584,7 @@ export class CircuitToCanvasDrawer {
           ctx: this.ctx,
           via: element as PcbVia,
           realToCanvasMat: this.realToCanvasMat,
-          colorMap: transparentDrillColorMap,
+          colorMap: this.colorMap,
           layer,
         })
       }
@@ -648,13 +622,11 @@ export class CircuitToCanvasDrawer {
       if (!shouldDrawElement(element, options)) continue
 
       if (element.type === "pcb_cutout") {
-        drawAsCutout(this.ctx, clearDrillHoles, () => {
-          drawPcbCutout({
-            ctx: this.ctx,
-            cutout: element as PcbCutout,
-            realToCanvasMat: this.realToCanvasMat,
-            colorMap: opaqueDrillColorMap,
-          })
+        drawPcbCutout({
+          ctx: this.ctx,
+          cutout: element as PcbCutout,
+          realToCanvasMat: this.realToCanvasMat,
+          colorMap: this.colorMap,
         })
       }
     }
@@ -782,5 +754,52 @@ export class CircuitToCanvasDrawer {
         })
       }
     }
+
+    if (options.clearDrillHoles) {
+      this.clearDrillHoles(elements, layer)
+    }
+  }
+
+  private clearDrillHoles(
+    elements: AnyCircuitElement[],
+    layer: LayerRef,
+  ): void {
+    const apertures = elements.filter(
+      (element) =>
+        element.type === "pcb_hole" ||
+        element.type === "pcb_plated_hole" ||
+        element.type === "pcb_via" ||
+        element.type === "pcb_cutout",
+    )
+    if (apertures.length === 0) return
+
+    const transparent = "rgba(0,0,0,0)"
+    const apertureDrawer = new CircuitToCanvasDrawer(this.ctx)
+    apertureDrawer.realToCanvasMat = this.realToCanvasMat
+    apertureDrawer.configure({
+      colorOverrides: {
+        copper: {
+          top: transparent,
+          bottom: transparent,
+          inner1: transparent,
+          inner2: transparent,
+          inner3: transparent,
+          inner4: transparent,
+          inner5: transparent,
+          inner6: transparent,
+          inner7: transparent,
+          inner8: transparent,
+        },
+        drill: "#000",
+      },
+    })
+
+    this.ctx.save()
+    this.ctx.globalCompositeOperation = "destination-out"
+    apertureDrawer.drawElements(apertures, {
+      layers: [`${layer}_copper` as PcbRenderLayer],
+      showPcbNotes: false,
+    })
+    this.ctx.restore()
   }
 }

--- a/tests/elements/clear-drill-holes.test.ts
+++ b/tests/elements/clear-drill-holes.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test"
+import { createCanvas } from "@napi-rs/canvas"
+import type { AnyCircuitElement } from "circuit-json"
+import { CircuitToCanvasDrawer } from "../../lib/drawer"
+
+const drillElements: AnyCircuitElement[] = [
+  {
+    type: "pcb_hole",
+    pcb_hole_id: "hole",
+    hole_shape: "circle",
+    hole_diameter: 10,
+    x: 20,
+    y: 20,
+  },
+  {
+    type: "pcb_plated_hole",
+    pcb_plated_hole_id: "plated-hole",
+    shape: "circle",
+    outer_diameter: 12,
+    hole_diameter: 6,
+    x: 40,
+    y: 20,
+    layers: ["top", "bottom"],
+  },
+  {
+    type: "pcb_via",
+    pcb_via_id: "via",
+    outer_diameter: 10,
+    hole_diameter: 4,
+    x: 60,
+    y: 20,
+    layers: ["top", "bottom"],
+  },
+  {
+    type: "pcb_cutout",
+    pcb_cutout_id: "cutout",
+    shape: "circle",
+    center: { x: 80, y: 20 },
+    radius: 5,
+  },
+]
+
+test("clearDrillHoles removes physical apertures and preserves copper rings", () => {
+  const canvas = createCanvas(100, 40)
+  const ctx = canvas.getContext("2d")
+  ctx.fillStyle = "#fff"
+  ctx.fillRect(0, 0, canvas.width, canvas.height)
+
+  const drawer = new CircuitToCanvasDrawer(ctx)
+  drawer.drawElements(drillElements, { clearDrillHoles: true })
+
+  const alphaAt = (x: number, y: number) => ctx.getImageData(x, y, 1, 1).data[3]
+
+  expect(alphaAt(20, 20)).toBe(0)
+  expect(alphaAt(40, 20)).toBe(0)
+  expect(alphaAt(60, 20)).toBe(0)
+  expect(alphaAt(80, 20)).toBe(0)
+  expect(alphaAt(45, 20)).toBe(255)
+  expect(alphaAt(64, 20)).toBe(255)
+})
+
+test("drills retain their configured color by default", () => {
+  const canvas = createCanvas(100, 40)
+  const ctx = canvas.getContext("2d")
+  const drawer = new CircuitToCanvasDrawer(ctx)
+
+  drawer.drawElements(drillElements)
+
+  expect(ctx.getImageData(20, 20, 1, 1).data[3]).toBe(255)
+  expect(ctx.getImageData(80, 20, 1, 1).data[3]).toBe(255)
+})


### PR DESCRIPTION
## Summary

- add an opt-in `clearDrillHoles` mode to `CircuitToCanvasDrawer.drawElements`
- clear non-plated holes and PCB cutouts with `destination-out`
- keep plated-hole and via drills transparent while preserving their copper rings
- retain the existing drill-color behavior by default

## Why

Consumers that composite PCB layers independently need drill geometry to remove alpha from an existing canvas. Painting a transparent drill color does not clear pixels that an earlier layer already drew, which allowed later layers such as silkscreen to appear over holes.

Keeping this behavior in `circuit-to-canvas` lets consumers reuse the canonical hole, via, plated-hole, and cutout geometry instead of duplicating it.

Consumer fix: [3d-viewer#973](https://github.com/tscircuit/3d-viewer/pull/973).

## Validation

- `bun test` — 151 passed
- `bun run build` — passed