### PR TITLE
ci: migrate npm publishing to OIDC

### DIFF
--- a/.github/workflows/bun-pver-release.yml
+++ b/.github/workflows/bun-pver-release.yml
@@ -10,6 +10,11 @@ env:
   UPSTREAM_REPOS: "" # comma-separated list, e.g. "eval,tscircuit,docs"
   UPSTREAM_PACKAGES_TO_UPDATE: "" # comma-separated list, e.g. "@tscircuit/core,@tscircuit/protos"
 
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -22,16 +27,16 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
+          package-manager-cache: false
       - run: npm install -g pver
       - run: bun install --frozen-lockfile
       - run: bun run build
       - run: pver release --no-push-main
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}
 
       - name: Get package version

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "circuit-to-canvas",
   "main": "dist/index.js",
   "version": "0.0.124",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tscircuit/circuit-to-canvas.git"
+  },
   "type": "module",
   "scripts": {
     "build": "tsup-node ./lib/index.ts --format esm --dts",


### PR DESCRIPTION
## Summary

- grant the release workflow GitHub OIDC permissions
- upgrade release builds to setup-node v6 and Node 24
- remove the long-lived npm publishing token
- ensure npm provenance can match this GitHub repository

## npm trusted publisher

Package: circuit-to-canvas
Repository: tscircuit/circuit-to-canvas
Workflow: bun-pver-release.yml
Allowed action: npm publish

## Validation

- release workflow YAML parses successfully
- package.json parses successfully
- git diff --check passes
- no NPM_TOKEN or NODE_AUTH_TOKEN reference remains in the release workflow